### PR TITLE
Drop not actual badge from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 `rackup` provides a command line interface for running a Rack-compatible application.
 
-[![Development Status](https://github.com/rack/rackup/workflows/Development/badge.svg)](https://github.com/rack/rackup/actions?workflow=Development)
-
 ## Installation
 
 ```bash


### PR DESCRIPTION
There is no GitHub action with the name `Development` in the repository.

So for now instead of badge displayed 'not found' image:
![image](https://user-images.githubusercontent.com/12499813/199847582-c1e304e3-eef3-4e59-afda-ab44119d4712.png)
