### PR TITLE
Update webrick version to 1.8.2

### DIFF
--- a/rackup.gemspec
+++ b/rackup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "rack", ">= 3"
-  spec.add_dependency "webrick", "~> 1.8"
+  spec.add_dependency "webrick", "~> 1.8.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Updates the pinned version of webrick to 1.8.2, since a CVE impacts earlier versions: https://nvd.nist.gov/vuln/detail/CVE-2024-47220