### PR TITLE
Bump `webrick` version

### DIFF
--- a/lib/rackup/version.rb
+++ b/lib/rackup/version.rb
@@ -4,5 +4,5 @@
 # Copyright, 2022-2023, by Samuel Williams.
 
 module Rackup
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/rackup.gemspec
+++ b/rackup.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "rack", ">= 3"
-  spec.add_dependency "webrick", "~> 1.8"
+  spec.add_dependency "webrick", "~> 1.8.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "minitest", "~> 5.0"


### PR DESCRIPTION
Description
An issue was discovered in the WEBrick toolkit through 1.8.1 for Ruby. It allows HTTP request smuggling by providing both a Content-Length header and a Transfer-Encoding header, e.g., "GET /admin HTTP/1.1\r\n" inside of a "POST /user HTTP/1.1\r\n" request. NOTE: the supplier's position is "Webrick should not be used in production."

References
https://nvd.nist.gov/vuln/detail/CVE-2024-47220
https://github.com/ruby/webrick/issues/145
https://github.com/ruby/webrick/commit/d88321da45dcd230ac2b4585cad4833d6d5e8841
https://github.com/ruby/webrick/commit/f5faca9222541591e1a7c3c97552ebb0c92733c7