### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/rackup.gemspec
+++ b/rackup.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.5"
 
+  spec.metadata = {
+    "rubygems_mfa_required" => "true"
+  }
+
   spec.add_dependency "rack", ">= 3"
   spec.add_dependency "webrick", "~> 1.8"
 


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/