### PR TITLE
Require the webrick handler when webrick is available

### DIFF
--- a/lib/rackup.rb
+++ b/lib/rackup.rb
@@ -6,3 +6,16 @@
 require_relative 'rackup/handler'
 require_relative 'rackup/server'
 require_relative 'rackup/version'
+
+begin
+  # Although webrick is gone from Ruby since 3.0, it still warns all the way
+  # through to 3.3. Only on 3.4 will requiring it not produce a warning anymore.
+  verbose, $VERBOSE = $VERBOSE, nil
+  require 'webrick'
+  # If the user happens to have webrick in their bundle, make the handler available.
+  require_relative 'rackup/handler/webrick'
+rescue LoadError
+  # ¯\_(ツ)_/¯
+ensure
+  $VERBOSE = verbose
+end


### PR DESCRIPTION
Followup to #23.

Even when users do add webrick to their gemfile, the handler is not available. This means that they either need to do that themselves, or their dependencies need to be updated. A quick search shows a handful of matches: https://github.com/search?q=%2FRackup%3A%3AHandler%3A%3AWEBrick%2F+lang%3Aruby+-is%3Afork&type=code

I noticed that capybara already does require the handler [here](https://github.com/teamcapybara/capybara/blob/0480f90168a40780d1398c75031a255c1819dce8/lib/capybara/registrations/servers.rb#L14) but it doesn't have to. Just requiring `rackup` previously made it available. I think it's a fair assumption that there is code out there that would be impacted by this.