### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/rackup

### DIFF
--- a/rackup.gemspec
+++ b/rackup.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/rack/rackup"
 
   spec.metadata = {
+    "changelog_uri" => spec.homepage + "/blob/main/releases.md",
     "rubygems_mfa_required" => "true",
     "source_code_uri" => "https://github.com/rack/rackup.git",
   }


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/rackup which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/#metadata