### PR TITLE
Fix references from `Rack::Server` to `Rackup::Server` in comments

### DIFF
--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -170,14 +170,14 @@ module Rackup
     # This method can be used to very easily launch a CGI application, for
     # example:
     #
-    #  Rack::Server.start(
+    #  Rackup::Server.start(
     #    :app => lambda do |e|
     #      [200, {'content-type' => 'text/html'}, ['hello world']]
     #    end,
     #    :server => 'cgi'
     #  )
     #
-    # Further options available here are documented on Rack::Server#initialize
+    # Further options available here are documented on Rackup::Server#initialize
     def self.start(options = nil)
       new(options).start
     end


### PR DESCRIPTION
It is likely a left-over from extracting out `Rack::Server` to a dedicate gem, so fixing comments in this trivial PR.