### PR TITLE
Fix Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -525,7 +525,7 @@ describe Rackup::Server do
 
     Process.kill(:INT, $$)
     t.join
-    open(pidfile.path) { |f| f.read.must_equal $$.to_s }
+    File.open(pidfile.path) { |f| f.read.must_equal $$.to_s }
   end if RUBY_VERSION >= "2.6" && RUBY_ENGINE == "ruby"
 
   it "check pid file presence and running process" do


### PR DESCRIPTION
https://github.com/rack/rackup/blob/c6cdd479172f042be405a36709ab27a2dff3a6e1/test/spec_server.rb#L528-L528

If Kernel.open is given a file name that starts with a \| character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to IO.read, IO.write, IO.binread, IO.binwrite, IO.foreach, IO.readlines and URI.open. |  


fix the problem, replace the use of `open(pidfile.path)` with `File.open(pidfile.path)`. This ensures that the file is opened directly, and there is no risk of shell command execution if the path starts with a pipe character. The change should be made on line 528 of `test/spec_server.rb`. No additional imports or method definitions are required, as `File` is a core Ruby class.

#### References
[Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
[Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)