### PR TITLE
Support lower case options.

### DIFF
--- a/lib/rackup/handler/webrick.rb
+++ b/lib/rackup/handler/webrick.rb
@@ -23,7 +23,7 @@ module Rackup
         if !options[:BindAddress] || options[:Host]
           options[:BindAddress] = options.delete(:Host) || default_host
         end
-        options[:Port] ||= 8080
+        options[:Port] = options[:port] || 8080
         if options[:SSLEnable]
           require 'webrick/https'
         end

--- a/lib/rackup/lobster.rb
+++ b/lib/rackup/lobster.rb
@@ -75,7 +75,7 @@ if $0 == __FILE__
   require_relative 'show_exceptions'
   require_relative 'lint'
   Rackup::Server.start(
-    app: Rack::ShowExceptions.new(Rack::Lint.new(Rackup::Lobster.new)), Port: 9292
+    app: Rack::ShowExceptions.new(Rack::Lint.new(Rackup::Lobster.new)), port: 9292
   )
   # :nocov:
 end

--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -460,7 +460,7 @@ module Rackup
       end
 
       def normalize_port_casing(options)
-        options[:port] = options[:port] || options[:Port].delete if options && options.is_a?(Hash)
+        options[:port] = options[:port] || options.delete(:Port) if options && options.is_a?(Hash)
       end
   end
 

--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -460,7 +460,10 @@ module Rackup
       end
 
       def normalize_port_casing(options)
-        options[:port] = options[:port] || options.delete(:Port) if options && options.is_a?(Hash)
+        if options && options.is_a?(Hash)
+          capitalized_port_value = options.delete(:Port)
+          options[:port] = options[:port] || capitalized_port_value
+        end
       end
   end
 

--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -466,9 +466,9 @@ module Rackup
               snakeified_key = snakeify(key).to_sym
               camelized_key = camelize(snakeified_key).to_sym
               normalized_value =
-                if !@options[snakeified_key].nil?
+                if @options.key?(snakeified_key)
                   @options[snakeified_key]
-                elsif !@options[camelized_key].nil?
+                elsif @options.key?(camelized_key)
                   @options[camelized_key]
                 else
                   @options[key]

--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -70,7 +70,7 @@ module Rackup
           }
 
           opts.on("-p", "--port PORT", "use PORT (default: 9292)") { |port|
-            options[:Port] = port
+            options[:port] = port
           }
 
           opts.on("-O", "--option NAME[=VALUE]", "pass VALUE to the server as option NAME. If no VALUE, sets it to true. Run '#{$0} -s SERVER -h' to get a list of options for SERVER") { |name|
@@ -179,6 +179,7 @@ module Rackup
     #
     # Further options available here are documented on Rackup::Server#initialize
     def self.start(options = nil)
+      normalize_port_casing(options)
       new(options).start
     end
 
@@ -252,7 +253,7 @@ module Rackup
       {
         environment: environment,
         pid: nil,
-        Port: 9292,
+        port: 9292,
         Host: default_host,
         AccessLog: [],
         config: "config.ru"
@@ -456,6 +457,10 @@ module Rackup
       def exit_with_pid(pid)
         $stderr.puts "A server is already running (pid: #{pid}, file: #{options[:pid]})."
         exit(1)
+      end
+
+      def normalize_port_casing(options)
+        options[:port] = options[:port] || options[:Port].delete if options && options.is_a?(Hash)
       end
   end
 

--- a/lib/rackup/server.rb
+++ b/lib/rackup/server.rb
@@ -179,7 +179,6 @@ module Rackup
     #
     # Further options available here are documented on Rackup::Server#initialize
     def self.start(options = nil)
-      normalize_port_casing(options)
       new(options).start
     end
 
@@ -232,6 +231,7 @@ module Rackup
       @ignore_options = []
 
       if options
+        normalize_port_casing(options)
         @use_default_options = false
         @options = options
         @app = options[:app] if options[:app]

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -52,9 +52,9 @@ describe Rackup::Server do
     server.app.must_equal "FOO"
   end
 
-  it "Options#parse parses -p and --port options into :Port" do
-    Rackup::Server::Options.new.parse!(%w[-p 1234]).must_equal :Port => '1234'
-    Rackup::Server::Options.new.parse!(%w[--port 1234]).must_equal :Port => '1234'
+  it "Options#parse parses -p and --port options into :port" do
+    Rackup::Server::Options.new.parse!(%w[-p 1234]).must_equal :port => '1234'
+    Rackup::Server::Options.new.parse!(%w[--port 1234]).must_equal :port => '1234'
   end
 
   it "Options#parse parses -D and --daemonize option into :daemonize" do

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -52,7 +52,7 @@ describe Rackup::Server do
     server.app.must_equal "FOO"
   end
 
-  it "Options#parse parses -p and --port options into :port" do
+  it "Options#parse parses -p and --port options into :Port" do
     Rackup::Server::Options.new.parse!(%w[-p 1234]).must_equal :port => '1234'
     Rackup::Server::Options.new.parse!(%w[--port 1234]).must_equal :port => '1234'
   end
@@ -482,9 +482,9 @@ describe Rackup::Server do
     t = Thread.new { server.start { |s| Thread.current[:server] = s } }
     t.join(0.01) until t[:server] && t[:server].status != :Stop
     body = if URI.respond_to?(:open)
-             URI.open("http://localhost:#{server.options[:Port]}/") { |f| f.read }
+             URI.open("http://localhost:#{server.options[:port]}/") { |f| f.read }
            else
-             open("http://localhost:#{server.options[:Port]}/") { |f| f.read }
+             open("http://localhost:#{server.options[:port]}/") { |f| f.read }
            end
     body.must_equal 'success'
 
@@ -512,7 +512,7 @@ describe Rackup::Server do
     t = Thread.new { server.start { |s| Thread.current[:server] = s } }
     t.join(0.01) until t[:server] && t[:server].status != :Stop
 
-    uri = URI.parse("https://localhost:#{server.options[:Port]}/")
+    uri = URI.parse("https://localhost:#{server.options[:port]}/")
 
     Net::HTTP.start("localhost", uri.port, use_ssl: true,
       verify_mode: OpenSSL::SSL::VERIFY_NONE) do |http|

--- a/test/spec_server.rb
+++ b/test/spec_server.rb
@@ -599,4 +599,41 @@ describe Rackup::Server do
     end
   end
 
+  it "normalize simple (non-camelized) words" do
+    options = {port: 8081}
+    server = Rackup::Server.new(options)
+    server.options[:port].must_equal 8081
+    server.options[:Port].must_equal 8081
+  end
+
+  it "normalize simple (non-camelized) words with snake-case having priority" do
+    options = {port: 8081, Port: 8082}
+    server = Rackup::Server.new(options)
+    server.options[:port].must_equal 8081
+    server.options[:Port].must_equal 8081
+  end
+
+  it "normalizes complex (camelized) words" do
+    options = {SSLEnable: true}
+    server = Rackup::Server.new(options)
+    server.options[:SSLEnable].must_equal true
+    server.options[:ssl_enable].must_equal true
+    server.options[:SslEnable].must_equal true
+  end
+
+  it "normalizes complex (camelized) words with camel-case having priority over actual key" do
+    options = {SSLEnable: true, ssl_enable: false}
+    server = Rackup::Server.new(options)
+    server.options[:SSLEnable].must_equal false
+    server.options[:ssl_enable].must_equal false
+    server.options[:SslEnable].must_equal false
+  end
+
+  it "normalizes complex (camelized) words with snake-case having priority over all" do
+    options = {SSLEnable: true, SslEnable: nil, ssl_enable: false}
+    server = Rackup::Server.new(options)
+    server.options[:SSLEnable].must_equal false
+    server.options[:ssl_enable].must_equal false
+    server.options[:SslEnable].must_equal false
+  end
 end


### PR DESCRIPTION
## Issue
Addressing: https://github.com/rack/rackup/issues/37#issuecomment-3353917170

## Approach

Given that we want to ensure backward compatibility until the option `Port` is fully deprecated, we still accept the `Port` option, but we delete it at `Rackup::Server` initialization and set its value to `:port`. 

In case a user, for whatever reason, chooses to pass both `port` and `Port`, `port` takes precedence.

I also changed the WEBrick initialization from using `Port` to using `port`.

I am also wondering:
1. Are we okay with doing this deletion tactic, or are we assuming that people use `server.options[:Port]` which will now fail, because we have deleted that? (I changed the tests to function with this new approach)
2. Perhaps this should also be done for `Host` ?
3. Should there some deprecation message be added when `Port` is deleted?

## Tests

Modified tests and they're all passing now:

<img width="789" height="385" alt="image" src="https://github.com/user-attachments/assets/343edfaa-c040-4488-9ca7-c30d0a725a4e" />

Please let me know what you think!


